### PR TITLE
Updated Appender to allow configuration via XML Configuration File

### DIFF
--- a/Ms.Azure.Logging.TestApp/Ms.Azure.Logging.TestApp.csproj
+++ b/Ms.Azure.Logging.TestApp/Ms.Azure.Logging.TestApp.csproj
@@ -77,6 +77,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="log4net.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Ms.Azure.Logging.TestApp/Program.cs
+++ b/Ms.Azure.Logging.TestApp/Program.cs
@@ -6,6 +6,7 @@ using Ms.Azure.Logging.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,8 +19,21 @@ namespace Ms.Azure.Logging.TestApp
 
         static void Main(string[] args)
         {
-            LoggingHelper.InitializeAzureTableLogging(CloudStorageAccount.DevelopmentStorageAccount);
-            (LogManager.GetRepository() as Hierarchy).Root.AddAppender(new log4net.Appender.ConsoleAppender { Layout = new PatternLayout("%date %-5level [%-3thread] %logger - %message%newline") });
+
+            bool UseXMLConfigurationFile = false;
+
+            if (UseXMLConfigurationFile)
+            {
+                // Configure Logger from XML Configuration File
+                log4net.Config.XmlConfigurator.ConfigureAndWatch(new FileInfo("log4net.config"));
+            }
+            else
+            {
+                // Configure Logger Via Code
+                LoggingHelper.InitializeAzureTableLogging(CloudStorageAccount.DevelopmentStorageAccount);
+                (LogManager.GetRepository() as Hierarchy).Root.AddAppender(new log4net.Appender.ConsoleAppender { Layout = new PatternLayout("%date %-5level [%-3thread] %logger - %message%newline") });
+            }
+            
             Logger.Info("Logging initialized");
             for (int i = 1; i <= 10; i++)
             {

--- a/Ms.Azure.Logging.TestApp/log4net.config
+++ b/Ms.Azure.Logging.TestApp/log4net.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+
+  <appender name="TestAppender" type="Ms.Azure.Logging.Appenders.TableStorageAppender, Ms.Azure.Logging">
+    <AccountName value="ietestnb" />
+    <AccessKey value="lTj/Bia0EvgfdoDBMbxaFECNJzlMeb8Ib8rwHj90tYCXjsTki1jl+adSexlz1cuMeS/ASRAWcm7co82W/ws4dA==" />
+    <TableName value="TestTable" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+    </layout>
+  </appender>
+
+  <root>
+    <level value="INFO" />
+    <appender-ref ref="TestAppender" />
+  </root>
+
+</log4net>

--- a/Ms.Azure.Logging.TestApp/log4net.config
+++ b/Ms.Azure.Logging.TestApp/log4net.config
@@ -2,8 +2,8 @@
 <log4net>
 
   <appender name="TestAppender" type="Ms.Azure.Logging.Appenders.TableStorageAppender, Ms.Azure.Logging">
-    <AccountName value="ietestnb" />
-    <AccessKey value="lTj/Bia0EvgfdoDBMbxaFECNJzlMeb8Ib8rwHj90tYCXjsTki1jl+adSexlz1cuMeS/ASRAWcm7co82W/ws4dA==" />
+    <AccountName value="[Storage Name]" />
+    <AccessKey value="[Access Key]" />
     <TableName value="TestTable" />
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />


### PR DESCRIPTION
Added a public property for Account Name and Access Key which allows configuration of the Appender via the log4net XML configuration file, which may be preferable for some.

Also updated the test program and added a sample configuration file to show the changes.
